### PR TITLE
Liz's suggested edits to bug-report.md

### DIFF
--- a/issue-templates/bug-report.md
+++ b/issue-templates/bug-report.md
@@ -11,12 +11,14 @@ __Tags__
 
 - [ ] coding error
 - [ ] design error
-- [ ] documentation error
+- [ ] documentation or content error
 - [ ] hardware problem
+- [ ] network or service outage
+- [ ] login or access permissions error
 
 __Description of issue__
 
-A clear and concise description of what the bug is.
+A clear and concise description of what the bug is and/or wording in any error messages encountered.
 
 __Expected behavior__
 


### PR DESCRIPTION
Two additional suggested tags and one edit - use 'documentation or content error' to capture any basic typos or unclear inline instruction/other erroneous content? Or should that be a separate tag? Also added onto the end of the Description of issue sentence.